### PR TITLE
Captcha not working on PHP 7.2.12 (Windows)

### DIFF
--- a/lib/Flux/Captcha.php
+++ b/lib/Flux/Captcha.php
@@ -37,7 +37,7 @@ class Flux_Captcha {
 				'chars'      => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWWXYZ0123456789',
 				'length'     => 5,
 				'background' => FLUX_DATA_DIR.'/captcha/background.png',
-				'fontPath'   => FLUX_DATA_DIR.'/captcha/fonts',
+				'fontPath'   => realpath(FLUX_DATA_DIR.'/captcha/fonts'),
 				'fontName'   => 'default.ttf',
 				'fontSize'   => 28,
 				'yPosition'  => 40,


### PR DESCRIPTION
Added realpath() to find the font
Tested on Windows (PHP 5.4.16 and 7.2.12) and on Ubuntu 18.04 (7.2.12)